### PR TITLE
Move Python dependencies into requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,16 @@ This bot is more of a learning exercise than anything else, no harm intended.
 
 It works by using phantom.js and selenium to grab a screenshot of the whole page and mark some points for reference. The next step is to crop just the article out of the page by using pillow, and then save it as a jpg to save bandwidth. Once it has done that it can post a comment on the reddit post with a link to the image.
 
-Needs all this installed to work:
+## Dependencies
 
-* praw        - get reddit posts and comment on them
-* selenium    - get screenshot through phantom.js
-* pillow      - crop screenshot to just the article
+Python package dependencies can be installed with `pip install -r requirements.txt`.
+
+Other system dependencies are:
+
 * libjpeg8    - allows pillow to save as jpeg
 * phantom.js  - renders the screenshot 
+
+## Output
 
 ![A picture of the output](http://i.imgur.com/gFrtGnb.png)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Pillow==2.8.2
+praw==2.1.21
+selenium==2.46.0


### PR DESCRIPTION
Python dependencies should be listed in requirements.txt rather than with the other dependencies. This has the advantages that:
- We can pin to specific versions of the packages that we know to be working, so that package upgrades don't break the bot
- It's just one command to install all the packages
